### PR TITLE
Add tag_keys for sensor and presence

### DIFF
--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -62,6 +62,8 @@
   data_format = "json"
   
   name_override = "beer"
+  
+  tag_keys = ["sensor", "presence"]
 
 [[processors.regex]]
   namepass = ["beer"]


### PR DESCRIPTION
Door sensor en presence een tag te maken (en de JSON aan te passen) wordt elke measurement ook daadwerkelijk één measurement in plaats van losse measurements voor de temperatuur en de presence, welke achteraf gecombineerd moeten worden (en het sensor-nummer extracted moet worden uit de tag-names met iets van Regex).

Voorbeeld-JSON:

```json
[
  {
    "sensor": 1,
    "temperature": 5,
    "presence": true
  },
  {
    "sensor": 2,
    "temperature": 21.1,
    "presence": false
  },
  {
    "sensor": 3,
    "temperature": 8,
    "presence": true
  }
]
```